### PR TITLE
Sri Laxmi | MOBN-2465 | Update. patientservice search to use lucene.

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - ocp-dev-bahmni-lite
-      - MOBN-2465
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - ocp-dev-bahmni-lite
+      - MOBN-2465
   workflow_dispatch:
 
 jobs:

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
         "angular-translate-storage-local": "*",
         "angular-ui-calendar": "1.0.2",
         "angular-ui-select2": "0.0.5",
-        "bahmni-commons-ng": "0.0.1",
+        "bahmni-commons-ng": "0.0.2",
         "fullcalendar": "2.7.3",
         "fullcalendar-scheduler": "1.3.2",
         "jquery": "1.9.1",

--- a/src/directives/patientSearch.js
+++ b/src/directives/patientSearch.js
@@ -12,7 +12,7 @@ angular.module('bahmni.appointments')
             link: {
                 pre: function ($scope) {
                     $scope.search = function () {
-                        return spinner.forPromise(patientService.search($scope.patient).then(function (response) {
+                        return spinner.forPromise(patientService.luceneSearch($scope.patient).then(function (response) {
                             return response.data.pageOfResults;
                         }));
                     };

--- a/test/directives/patientSearch.spec.js
+++ b/test/directives/patientSearch.spec.js
@@ -6,8 +6,8 @@ describe("Patient Search", function () {
     beforeEach(module('bahmni.appointments', function ($provide) {
         $location = jasmine.createSpyObj('$location', ['search']);
         $location.search.and.returnValue({});
-        patientService = jasmine.createSpyObj('patientService', ['search','getPatient']);
-        patientService.search.and.returnValue(specUtil.simplePromise({data: {}}));
+        patientService = jasmine.createSpyObj('patientService', ['search','getPatient','luceneSearch']);
+        patientService.luceneSearch.and.returnValue(specUtil.simplePromise({data: {}}));
         spinner = jasmine.createSpyObj('spinner', ['forPromise']);
         spinner.forPromise.and.callFake(function (param) {
             return {

--- a/test/directives/patientSearch.spec.js
+++ b/test/directives/patientSearch.spec.js
@@ -50,7 +50,7 @@ describe("Patient Search", function () {
         var compiledScope = element.isolateScope();
         compiledScope.patient = 'test patient';
         compiledScope.search();
-        expect(patientService.search).toHaveBeenCalledWith(compiledScope.patient);
+        expect(patientService.luceneSearch).toHaveBeenCalledWith(compiledScope.patient);
     });
 
     it('should build response map with patient name and identifier for list of patients', function () {


### PR DESCRIPTION
[MOBN-2465](https://msfprojects.atlassian.net/browse/MOBN-2465)

In the search of list view, in appointments module we are unable to search with patient id.

Update the bahmni-commons-ng package to 0.0.2. This package forwards the normal search call to lucene search call. 
And update patientsevice to use the newly introduced lucenesearch method instead of normal search method